### PR TITLE
Formula revised

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A = P*r*t
 
 // A = total amount interest owed
 
-A = A + (P*r*t)
+A = P + (P*r*t)
 
 // A = total amount owed with interest
 ```

--- a/README.md
+++ b/README.md
@@ -41,9 +41,15 @@ Verify that it's working by running your script, `node server.js` and opening th
 * Calculate the monthly payment of a loan defined at `$scope.principal` over 4 years (48 months) with the interest rate retrieved. Store the value as `$scope.monthly_payment`. Hint: use the basic formula for calculating the total loan amount with interest:
 
 ```
+// P = Principal amount
+// r = interest rate
+// t = time (in years)
+
 A = P*r*t
-//A = total amount owed after interest
-//P = Principal amount
-//r = interest rate
-//t = time (in years)
+
+// A = total amount interest owed
+
+A = A + (P*r*t)
+
+// A = total amount owed with interest
 ```


### PR DESCRIPTION
Formula was incomplete or incorrect. The wording implied that A equals amount owed _after interest. However, P_r*t equals precisely the amount *of interest only. Example:

P: $10,000
r: 5%
t: 5 (years)

P_r_t = $2500

Which is the amount of interest only.

However, 
P + (P_r_t) = $12500

Which is the amount *with interest.

Either the formula or the wording must be corrected.
